### PR TITLE
feat: service id

### DIFF
--- a/clickhouse/init_db.sql
+++ b/clickhouse/init_db.sql
@@ -2,28 +2,30 @@ CREATE DATABASE IF NOT EXISTS events;
 
 CREATE TABLE IF NOT EXISTS events.tts (
     timestamp DateTime64(3) DEFAULT now64(3),
-    service_id String,
+    service_id LowCardinality(String),
     language LowCardinality(String),
     speaker LowCardinality(String),
     chars UInt16,
     transed Boolean DEFAULT false
 ) ENGINE = MergeTree()
-ORDER BY (timestamp, service_id)
+ORDER BY (service_id, timestamp)
 PARTITION BY toYYYYMM(timestamp);
 
 CREATE TABLE IF NOT EXISTS events.commands (
     timestamp DateTime64(3) DEFAULT now64(3),
+    service_id LowCardinality(String),
     user_id String,
     type LowCardinality(String),
-    name LowCardinality(String),
+    name LowCardinality(String)
 ) ENGINE = MergeTree()
-ORDER BY (timestamp, name)
+ORDER BY (service_id, name, timestamp)
 PARTITION BY toYYYYMM(timestamp);
 
 CREATE TABLE IF NOT EXISTS events.actions (
     timestamp DateTime64(3) DEFAULT now64(3),
+    service_id LowCardinality(String),
     guild_id String,
-    name LowCardinality(String),
+    name LowCardinality(String)
 ) ENGINE = MergeTree()
-ORDER BY (timestamp, name)
+ORDER BY (service_id, name, timestamp)
 PARTITION BY toYYYYMM(timestamp);

--- a/server/schemas/actions.json
+++ b/server/schemas/actions.json
@@ -4,6 +4,7 @@
     "description": "Schema for Wamellow Command usage tracking events",
     "type": "object",
     "required": [
+        "service_id",
         "guild_id",
         "name"
     ],
@@ -11,6 +12,10 @@
         "timestamp": {
             "type": "string",
             "format": "date-time"
+        },
+        "service_id": {
+            "type": "string",
+            "minLength": 1
         },
         "guild_id": {
             "type": "string",
@@ -27,6 +32,7 @@
     "additionalProperties": false,
     "x-clickhouse-column-order": [
         "timestamp",
+        "service_id",
         "guild_id",
         "name"
     ]

--- a/server/schemas/commands.json
+++ b/server/schemas/commands.json
@@ -4,6 +4,7 @@
     "description": "Schema for Wamellow Command usage tracking events",
     "type": "object",
     "required": [
+        "service_id",
         "user_id",
         "type",
         "name"
@@ -13,6 +14,10 @@
             "type": "string",
             "format": "date-time"
         },
+        "service_id": {
+            "type": "string",
+            "minLength": 1
+        },
         "user_id": {
             "type": "string",
             "minLength": 10,
@@ -21,7 +26,14 @@
         },
         "type": {
             "type": "string",
-            "enum": ["command", "context", "button", "select", "modal", "text"]
+            "enum": [
+                "command",
+                "context",
+                "button",
+                "select",
+                "modal",
+                "text"
+            ]
         },
         "name": {
             "type": "string",
@@ -32,6 +44,7 @@
     "additionalProperties": false,
     "x-clickhouse-column-order": [
         "timestamp",
+        "service_id",
         "user_id",
         "type",
         "name"


### PR DESCRIPTION
Adds service_id column to events.commands and events.actions tables/schemas and makes it the leading ORDER BY key across all three event tables for consistent multi-tenant event partitioning.